### PR TITLE
Migrate to React Native 0.39

### DIFF
--- a/SmartScrollView.js
+++ b/SmartScrollView.js
@@ -241,6 +241,7 @@ class SmartScrollView extends Component {
             showsVerticalScrollIndicator     = { showsVerticalScrollIndicator }
             keyboardShouldPersistTaps        = { true }
             bounces                          = { false }
+            keyboardDismissMode              = {keyboardDismissMode}
           >
             {content}
           </ScrollView>
@@ -266,6 +267,7 @@ SmartScrollView.propTypes = {
   contentInset:                 PropTypes.object,
   onScroll:                     PropTypes.func,
   onRefFocus:                   PropTypes.func,
+  keyboardDismissMode:          PropTypes.string
 };
 
 SmartScrollView.defaultProps = {
@@ -275,7 +277,8 @@ SmartScrollView.defaultProps = {
   showsVerticalScrollIndicator: true,
   contentInset:                 {top: 0, left: 0, bottom: 0, right: 0},
   onScroll:                     () => {},
-  onRefFocus:                   () => {}
+  onRefFocus:                   () => {},
+  keyboardDismissMode:          'none'
 };
 
 export default SmartScrollView;

--- a/SmartScrollView.js
+++ b/SmartScrollView.js
@@ -161,7 +161,8 @@ class SmartScrollView extends Component {
       zoomScale,
       showsVerticalScrollIndicator,
       contentInset,
-      onScroll
+      onScroll,
+      keyboardDismissMode
     }                = this.props;
     let inputIndex   = 0;
     const smartClone = (element, i) => {

--- a/SmartScrollView.js
+++ b/SmartScrollView.js
@@ -5,7 +5,6 @@ import React, {
 
 import ReactNative, {
   View,
-  StyleSheet,
   ScrollView,
   Keyboard,
   Dimensions,
@@ -252,13 +251,6 @@ class SmartScrollView extends Component {
   }
 }
 
-const styles = StyleSheet.create({
-  flex1: {
-    flexGrow: 1,
-    flexBasis:1
-  }
-});
-
 SmartScrollView.propTypes = {
   forceFocusField:              PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   scrollContainerStyle:         View.propTypes.style,
@@ -272,7 +264,7 @@ SmartScrollView.propTypes = {
 };
 
 SmartScrollView.defaultProps = {
-  scrollContainerStyle:         styles.flex1,
+  scrollContainerStyle:         {},
   scrollPadding:                5,
   zoomScale:                    1,
   showsVerticalScrollIndicator: true,

--- a/SmartScrollView.js
+++ b/SmartScrollView.js
@@ -254,7 +254,8 @@ class SmartScrollView extends Component {
 
 const styles = StyleSheet.create({
   flex1: {
-    flexGrow: 1
+    flexGrow: 1,
+    flexBasis:1
   }
 });
 

--- a/SmartScrollView.js
+++ b/SmartScrollView.js
@@ -224,14 +224,12 @@ class SmartScrollView extends Component {
         style = {scrollContainerStyle}
         onLayout={(e) => this._layout = e.nativeEvent.layout}
       >
-        <View
-          style     = {this.state.keyBoardUp ? { height: this.state.scrollWindowHeight } : styles.flex1}
-        >
+        <View>
           <ScrollView
             ref                              = { component => this._smartScroll=component }
             automaticallyAdjustContentInsets = { false }
             scrollsToTop                     = { false }
-            style                            = { styles.flex1 }
+            style     = {this.state.keyBoardUp ? { height: this.state.scrollWindowHeight } : {}}
             onScroll                         = { (event) => {
               this._updateScrollPosition(event)
               onScroll(event)

--- a/SmartScrollView.js
+++ b/SmartScrollView.js
@@ -161,7 +161,8 @@ class SmartScrollView extends Component {
       showsVerticalScrollIndicator,
       contentInset,
       onScroll,
-      keyboardDismissMode
+      keyboardDismissMode,
+      keyboardShouldPersistTaps
     }                = this.props;
     let inputIndex   = 0;
     const smartClone = (element, i) => {
@@ -217,7 +218,6 @@ class SmartScrollView extends Component {
     }
 
     const content = recursivelyCheckAndAdd(scrollChildren, '0');
-
     return (
       <View
         ref   = { component => this._container=component }
@@ -239,7 +239,7 @@ class SmartScrollView extends Component {
             contentInset                     = { contentInset }
             zoomScale                        = { zoomScale }
             showsVerticalScrollIndicator     = { showsVerticalScrollIndicator }
-            keyboardShouldPersistTaps        = 'always'
+            keyboardShouldPersistTaps        = {keyboardShouldPersistTaps}
             bounces                          = { false }
             keyboardDismissMode              = {keyboardDismissMode}
           >
@@ -260,7 +260,8 @@ SmartScrollView.propTypes = {
   contentInset:                 PropTypes.object,
   onScroll:                     PropTypes.func,
   onRefFocus:                   PropTypes.func,
-  keyboardDismissMode:          PropTypes.string
+  keyboardDismissMode:          PropTypes.string,
+  keyboardShouldPersistTaps:          PropTypes.string,
 };
 
 SmartScrollView.defaultProps = {
@@ -271,7 +272,8 @@ SmartScrollView.defaultProps = {
   contentInset:                 {top: 0, left: 0, bottom: 0, right: 0},
   onScroll:                     () => {},
   onRefFocus:                   () => {},
-  keyboardDismissMode:          'none'
+  keyboardDismissMode:          'none',
+  keyboardShouldPersistTaps:          'always'
 };
 
 export default SmartScrollView;
@@ -292,3 +294,6 @@ export default SmartScrollView;
 //     lastTap: currentTap
 //   })
 // }
+/**
+ * Created by Meysam on 5/7/17.
+ */

--- a/SmartScrollView.js
+++ b/SmartScrollView.js
@@ -129,7 +129,11 @@ class SmartScrollView extends Component {
       this[ref].measureLayout(num, (X,Y,W,H) => {
         const py = Y - scrollPosition;
 
-        if ( py + H > scrollWindowHeight ){
+        if (!scrollWindowHeight) {
+          setTimeout(() => {
+            this._focusNode(ref);
+          }, 100);
+        } else if ( py + H > scrollWindowHeight ){
           const nextScrollPosition = (Y + H) - scrollWindowHeight + scrollPadding;
 
           this._smartScroll.scrollTo({y: nextScrollPosition});

--- a/SmartScrollView.js
+++ b/SmartScrollView.js
@@ -122,7 +122,7 @@ class SmartScrollView extends Component {
     const num               = ReactNative.findNodeHandle(this._smartScroll);
     const strippedBackRef   = ref.slice('input_'.length);
 
-    setTimeout(() => {
+    this[ref] && setTimeout(() => {
       onRefFocus(strippedBackRef);
       this.setState({focusedField: strippedBackRef})
       this[ref].measureLayout(num, (X,Y,W,H) => {

--- a/SmartScrollView.js
+++ b/SmartScrollView.js
@@ -250,7 +250,7 @@ class SmartScrollView extends Component {
 
 const styles = StyleSheet.create({
   flex1: {
-    flex: 1
+    flexGrow: 1
   }
 });
 

--- a/SmartScrollView.js
+++ b/SmartScrollView.js
@@ -240,7 +240,7 @@ class SmartScrollView extends Component {
             contentInset                     = { contentInset }
             zoomScale                        = { zoomScale }
             showsVerticalScrollIndicator     = { showsVerticalScrollIndicator }
-            keyboardShouldPersistTaps        = { true }
+            keyboardShouldPersistTaps        = 'always'
             bounces                          = { false }
             keyboardDismissMode              = {keyboardDismissMode}
           >


### PR DESCRIPTION
[PR from original repo](https://github.com/nikhilaravi/react-native-smart-scroll-view/pull/35) by @izadmehr

> migrate to react native 0.39.
> change flex:1 to flexGrow:1. This would fix the following error which occured on the keyboard open: attempted to set an invalid frame to inner scrollview